### PR TITLE
downgrade to cxf 3.0.6 to allow jdk 6 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <beanutils.version>1.9.2</beanutils.version>
-    <cxf.version>3.1.2</cxf.version>
+    <cxf.version>3.0.6</cxf.version>
     <cxf-xjc.version>3.0.5</cxf-xjc.version>
     <gson.version>2.3.1</gson.version>
     <junit.version>4.12</junit.version>


### PR DESCRIPTION
Hi @imurdock, this is a tiny change that could lead to a great relief on legacy systems. Could you please check it doesn't break anything in your test suite? We'll do so. Thanks.