### PR TITLE
Add support of BASE_16_ENCRYPTED_EMAIL column type to ETDataExtension…

### DIFF
--- a/src/main/java/com/exacttarget/fuelsdk/ETDataExtensionColumn.java
+++ b/src/main/java/com/exacttarget/fuelsdk/ETDataExtensionColumn.java
@@ -316,7 +316,8 @@ public class ETDataExtensionColumn extends ETSoapObject {
         LOCALE("Locale"),
         NUMBER("Number"),
         PHONE("Phone"),
-        TEXT("Text");
+        TEXT("Text"),
+        BASE_16_ENCRYPTED_EMAIL("Base16EncryptedEmail");
         private final String value;
 
         Type(String value) {


### PR DESCRIPTION
…Column

Add support of BASE_16_ENCRYPTED_EMAIL column type;
Fixes:
```
Caused by: java.lang.IllegalArgumentException: No enum constant com.exacttarget.fuelsdk.ETDataExtensionColumn.Type.BASE_16_ENCRYPTED_EMAIL
  at java.lang.Enum.valueOf(Enum.java:238)
  at com.exacttarget.fuelsdk.ETSoapObject$EnumConverter.convert(ETSoapObject.java:989)
  at org.apache.commons.beanutils.BeanUtilsBean.convert(BeanUtilsBean.java:1072)
  at org.apache.commons.beanutils.BeanUtilsBean.setProperty(BeanUtilsBean.java:1005)
  at org.apache.commons.beanutils.BeanUtils.setProperty(BeanUtils.java:454)
  at com.exacttarget.fuelsdk.ETSoapObject.fromInternal(ETSoapObject.java:1097)
  ... 45 more
```

when selecting or deleting entries in DEs with encrypted email column