### PR TITLE
TSE required changes

### DIFF
--- a/src/main/java/com/exacttarget/fuelsdk/ETClient.java
+++ b/src/main/java/com/exacttarget/fuelsdk/ETClient.java
@@ -66,10 +66,10 @@ public class ETClient {
             "https://auth.exacttargetapis.com";
     private static final String PATH_REQUESTTOKEN =
             "/v1/requestToken";
-    private static final String PATH_REQUESTTOKEN_LEGACY =
-            "/v1/requestToken?legacy=1";
     private static final String PATH_ENDPOINTS_SOAP =
             "/platform/v1/endpoints/soap";
+    private static final String DEFAULT_SOAP_ENDPOINT =
+            "https://webservice.exacttarget.com/Service.asmx";
 
     private ETConfiguration configuration = null;
 
@@ -97,6 +97,9 @@ public class ETClient {
     private String refreshToken = null;
 
     private long tokenExpirationTime = 0;
+    private static long soapEndpointExpiration = 0;
+    private static String fetchedSoapEndpoint = null;
+    private static final long cacheDurationInMillis = 1000 * 60 * 15;
 
     /** 
     * Class constructor, Initializes a new instance of the class.
@@ -155,17 +158,7 @@ public class ETClient {
             authConnection = new ETRestConnection(this, authEndpoint, true);
             requestToken();
             restConnection = new ETRestConnection(this, endpoint);
-            if (soapEndpoint == null) {
-                //
-                // If a SOAP endpoint isn't specified automatically determine it:
-                //
-
-                ETRestConnection.Response response = restConnection.get(PATH_ENDPOINTS_SOAP);
-                String responsePayload = response.getResponsePayload();
-                JsonParser jsonParser = new JsonParser();
-                JsonObject jsonObject = jsonParser.parse(responsePayload).getAsJsonObject();
-                soapEndpoint = jsonObject.get("url").getAsString();
-            }
+            FetchSoapEndpoint();
             soapConnection = new ETSoapConnection(this, soapEndpoint, accessToken);
         } else {
             if (username == null || password == null) {
@@ -195,6 +188,35 @@ public class ETClient {
             logger.trace("  authEndpoint = " + authEndpoint);
             logger.trace("  soapEndpoint = " + soapEndpoint);
             logger.trace("  autoHydrateObjects = " + autoHydrateObjects);
+        }
+    }
+
+    private void FetchSoapEndpoint() {
+        if (soapEndpoint == null) {
+            //
+            // If a SOAP endpoint isn't specified automatically determine it:
+            //
+            try {
+                if(fetchedSoapEndpoint == null || soapEndpointExpiration - System.currentTimeMillis() < 0) {
+                    ETRestConnection.Response response = restConnection.get(PATH_ENDPOINTS_SOAP);
+                    if (response.getResponseCode() == 200) {
+                        String responsePayload = response.getResponsePayload();
+                        JsonParser jsonParser = new JsonParser();
+                        JsonObject jsonObject = jsonParser.parse(responsePayload).getAsJsonObject();
+                        soapEndpoint = jsonObject.get("url").getAsString();
+                        fetchedSoapEndpoint = soapEndpoint;
+                        soapEndpointExpiration = System.currentTimeMillis() + cacheDurationInMillis;
+                    } else {
+                        soapEndpoint = DEFAULT_SOAP_ENDPOINT;
+                    }
+                }
+                else {
+                    soapEndpoint = fetchedSoapEndpoint;
+                }
+            }
+            catch(ETSdkException ex) {
+                soapEndpoint = DEFAULT_SOAP_ENDPOINT;
+            }
         }
     }
 
@@ -323,11 +345,8 @@ public class ETClient {
         String requestPayload = gson.toJson(jsonObject);
 
         ETRestConnection.Response response = null;
-        if (configuration.isTrue("requestLegacyToken")) {
-            response = authConnection.post(PATH_REQUESTTOKEN_LEGACY, requestPayload);
-        } else {
-            response = authConnection.post(PATH_REQUESTTOKEN, requestPayload);
-        }
+
+        response = authConnection.post(PATH_REQUESTTOKEN, requestPayload);
 
         if (response.getResponseCode() != HttpURLConnection.HTTP_OK) {
             throw new ETSdkException("error obtaining access token "

--- a/src/test/java/com/exacttarget/fuelsdk/ETClientTest.java
+++ b/src/test/java/com/exacttarget/fuelsdk/ETClientTest.java
@@ -34,6 +34,7 @@
 
 package com.exacttarget.fuelsdk;
 
+import java.lang.reflect.Field;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
@@ -196,6 +197,25 @@ public class ETClientTest {
         assertNull(folder.getIsActive());
         assertNull(folder.getIsEditable());
         assertNull(folder.getAllowChildren());
+    }
+
+    @Test
+    public void testSoapEndpointCaching()
+            throws ETSdkException, NoSuchFieldException, IllegalAccessException {
+        ETClient client1 = new ETClient("fuelsdk.properties");
+        ETClient client2 = new ETClient("fuelsdk.properties");
+
+        Field instance1SoapEndpointExpirationField = client1.getClass().getDeclaredField("soapEndpointExpiration");
+        instance1SoapEndpointExpirationField.setAccessible(true);
+        long instance1SoapEndpointExpiration = instance1SoapEndpointExpirationField.getLong(null);
+
+        Field instance2SoapEndpointExpirationField = client2.getClass().getDeclaredField("soapEndpointExpiration");
+        instance2SoapEndpointExpirationField.setAccessible(true);
+        long instance2SoapEndpointExpiration = instance2SoapEndpointExpirationField.getLong(null);
+
+        assertTrue(instance1SoapEndpointExpiration > 0);
+        assertTrue(instance2SoapEndpointExpiration > 0);
+        assertEquals(instance1SoapEndpointExpiration, instance2SoapEndpointExpiration);
     }
 
     //


### PR DESCRIPTION
Gus Tickets:
 - https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000005b1DVIAY/view
 - https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000005b3pEIAQ/view
 - https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000005b3tVIAQ/view

Description
 - Rest, Auth and SOAP endpoints should be configurable
 - Rest and Auth should be set to default values if not defined in the fuelsdk.properties file
 - SOAP endpoint should be fetched through a REST call if not set in the fuelsdk.properties file. If the call is successful, the returned value should be used for the SOAP endpoint. If the call fails, the SOAP endpoint should be set to a default value.
- Cached in memory the fetched SOAP endpoint value for 15 minutes, so that any ETClient instance will use the cached value and not make REST calls to retrieve it. Added unit test to verify caching for 2 instances of ETClient.
- Removed the legacyToken query string parameter support.


