### PR TITLE
Instantiated Soap object if continueRequest!=null

### DIFF
--- a/src/main/java/com/exacttarget/fuelsdk/ETSoapObject.java
+++ b/src/main/java/com/exacttarget/fuelsdk/ETSoapObject.java
@@ -346,7 +346,14 @@ public abstract class ETSoapObject extends ETApiObject {
 
         RetrieveRequestMsg retrieveRequestMsg = new RetrieveRequestMsg();
         retrieveRequestMsg.setRetrieveRequest(retrieveRequest);
-
+        
+        if (soapObjectName != null) {
+                retrieveRequest.setObjectType(soapObjectName);
+                soap = connection.getSoap("retrieve", soapObjectName);
+            } else {
+                retrieveRequest.setObjectType(internalType.getSimpleName());
+                soap = connection.getSoap("retrieve", internalType.getSimpleName());
+            }
         RetrieveResponseMsg retrieveResponseMsg = soap.retrieve(retrieveRequestMsg);
 
         if (logger.isTraceEnabled()) {


### PR DESCRIPTION
If continueRequest was passed with the call i.e. continueRequest!=null, then Soap object was not instantiated to connection.getSoap() because of that I was getting null pointer exception while making ContinueRequest calls.