### PR TITLE
Quote DE Key in expression when selecting rows

### DIFF
--- a/src/main/java/com/exacttarget/fuelsdk/ETDataExtension.java
+++ b/src/main/java/com/exacttarget/fuelsdk/ETDataExtension.java
@@ -750,7 +750,7 @@ public class ETDataExtension extends ETSoapObject {
         if (filter.getProperties().isEmpty()) {
             filter.setProperties(getColumnNames());
         }
-        return ETDataExtension.select(getClient(), "key=" + getKey(), page, pageSize, filter);
+        return ETDataExtension.select(getClient(), "key=\"" + getKey() + "\"", page, pageSize, filter);
     }
 
     /**
@@ -801,7 +801,7 @@ public class ETDataExtension extends ETSoapObject {
         if (f.getProperties().isEmpty()) {
             f.setProperties(getColumnNames());
         }
-        return ETDataExtension.select(getClient(), "key=" + getKey(), page, pageSize, f);
+        return ETDataExtension.select(getClient(), "key=\"" + getKey() + "\"", page, pageSize, f);
     }
 
     /**


### PR DESCRIPTION
CustomerKey (External Key) may contain spaces, and if it does than parser takes the first word from it

If the key is "Test DE 2" we will have "key=[Test]" in the parsed expression

At least this bug may cause inability to retrieve data
At most this may lead to data corruption if we have intersecting keys like "Test" and "Test DE"