### PR TITLE
columns in DataExtensions are always pre-initialized with `new ArrayList<>`

### DIFF
--- a/src/main/java/com/exacttarget/fuelsdk/ETDataExtension.java
+++ b/src/main/java/com/exacttarget/fuelsdk/ETDataExtension.java
@@ -361,7 +361,7 @@ public class ETDataExtension extends ETSoapObject {
     public List<String> getColumnNames()
         throws ETSdkException
     {
-        if (columns == null) {
+        if (columns == null || columns.isEmpty()) {
             columns = retrieveColumns();
         }
         return getColumnNames(columns);


### PR DESCRIPTION
Columns in DataExtensions are always pre-initialized with `new ArrayList<>`
