### PR TITLE
ErrorCodeId is now supported in SubscriberResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Salesforce Marketing Cloud Java SDK
+Salesforce Marketing Cloud Java SDK - TEST
 ===================================
 
 The Salesforce Marketing Cloud Java SDK enables developers to easily

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Salesforce Marketing Cloud Java SDK - TEST
+Salesforce Marketing Cloud Java SDK
 ===================================
 
 The Salesforce Marketing Cloud Java SDK enables developers to easily
@@ -24,6 +24,10 @@ Java platform. Among other things, the SDK:
 
 For more information about the Java SDK and how to use it, please see
 the Javadocs at http://salesforce-marketingcloud.github.io/FuelSDK-Java/.
+
+New Features in Version 1.5.2
+------------
+* Added Support for SubscriberResult ErrorCodeID
 
 New Features in Version 1.5.1
 ------------

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.salesforce-marketingcloud</groupId>
   <artifactId>fuelsdk</artifactId>
-  <version>1.5.1</version>
+  <version>1.5.2</version>
   <name>Salesforce Marketing Cloud Java SDK</name>
   <description>Salesforce Marketing Cloud Java SDK</description>
   <url>https://github.com/salesforce-marketingcloud/FuelSDK-Java</url>

--- a/src/main/resources/etframework.wsdl
+++ b/src/main/resources/etframework.wsdl
@@ -2421,6 +2421,7 @@
           <element name="ErrorCode" minOccurs="1" maxOccurs="1" type="xsd:string" />
           <element name="ErrorDescription" minOccurs="0" maxOccurs="1" type="xsd:string" />
           <element name="Ordinal" minOccurs="0" type="xsd:int" />
+          <element name="ErrorCodeID" minOccurs="0" maxOccurs="1" type="xsd:int" />
         </sequence>
       </complexType>
       <element name="SubscriberResult" type="tns:SubscriberResult" />

--- a/src/test/java/com/exacttarget/fuelsdk/ETTriggeredTest.java
+++ b/src/test/java/com/exacttarget/fuelsdk/ETTriggeredTest.java
@@ -5,15 +5,17 @@
  */
 package com.exacttarget.fuelsdk;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.UUID;
 
 import com.exacttarget.fuelsdk.internal.*;
-import com.exacttarget.fuelsdk.annotations.*;
-import java.util.*;
+import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -220,6 +222,62 @@ public class ETTriggeredTest {
             Logger.getLogger(ETTriggeredTest.class.getName()).log(Level.SEVERE, null, ex);
             ex.printStackTrace();
         }        
+    }
+
+    @Test
+    public void fuelSdkSendEmailWithValidEmail()
+    {
+        try
+        {
+            ETTriggeredEmail triggeredSendDefinition = new ETTriggeredEmail();
+            triggeredSendDefinition.setCustomerKey(tsName);
+            triggeredSendDefinition.setClient(client);
+
+            ETSubscriber subscriber = new ETSubscriber();
+            subscriber.setEmailAddress("jane.doe@gmail.com");
+            subscriber.setSubscriberKey("jane.doe@gmail.com");
+            
+            List<ETSubscriber> subscribers = new ArrayList<ETSubscriber>();
+            subscribers.add(subscriber);
+            ETResponse<ETTriggeredEmail> createResponse = triggeredSendDefinition
+                    .send(subscribers);
+            System.out.println("TEST");
+
+            assertEquals(createResponse.getResponseCode(), "OK");
+            assertEquals(createResponse.getResponseMessage(), "TriggeredSendDefinition deleted");
+
+        }
+        catch (Exception ex)
+        {
+            fail(ex.toString());
+        }
+    }
+
+    @Test
+    public void fuelSdkSendEmailWithInValidEmail()
+    {
+        try
+        {
+            ETTriggeredEmail triggeredSendDefinition = new ETTriggeredEmail();
+            triggeredSendDefinition.setCustomerKey(tsName);
+            triggeredSendDefinition.setClient(client);
+
+            ETSubscriber subscriber = new ETSubscriber();
+            subscriber.setEmailAddress("jane.doe+spam@gmail.com");
+            subscriber.setSubscriberKey("jane.doe+spam@gmail.com");
+
+            List<ETSubscriber> subscribers = new ArrayList<ETSubscriber>();
+            subscribers.add(subscriber);
+            ETResponse<ETTriggeredEmail> createResponse = triggeredSendDefinition
+                    .send(subscribers);
+
+            assertEquals(createResponse.getResponseCode(), "Error");
+
+        }
+        catch (Exception ex)
+        {
+            fail(ex.toString());
+        }
     }
     
 /*    public static void main(String[] args){


### PR DESCRIPTION
Fixes the unmarshalling exception that was occurring since SFMC updated their WSDL