### PR TITLE
Log4j upgrade for Security Vulnerability CVE-2021-44832

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Java platform. Among other things, the SDK:
 For more information about the Java SDK and how to use it, please see
 the Javadocs at http://salesforce-marketingcloud.github.io/FuelSDK-Java/.
 
+New Features in Version 1.6.0
+------------
+* This version upgrades SDK to use log4j version 2.3.2 that contains fix for Security Vulnerability CVE-2021-44832. Log4j upgrade introduces breaking changes to the way log4j is configured. This version of SDK is using Log4j2 bridge to help mitigate the issue. If client overrides log4j properties they might need to be converted to the new log4j2 format. Please see this link for more details on migrating to log4j v2: https://logging.apache.org/log4j/log4j-2.3.2/manual/migration.html.
+
 New Features in Version 1.5.1
 ------------
 * Added Support for Java 11

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ the Javadocs at http://salesforce-marketingcloud.github.io/FuelSDK-Java/.
 
 New Features in Version 1.6.0
 ------------
-* This version upgrades SDK to use log4j version 2.3.2 that contains fix for [Security Vulnerability CVE-2021-44832](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-44832). Log4j upgrade introduces breaking changes to the way log4j is configured. This version of SDK is using Log4j2 bridge to help with version migration. If client overrides log4j properties they might need to be converted to the new log4j2 format. Please see this link for more details on migrating to log4j v2: https://logging.apache.org/log4j/log4j-2.3.2/manual/migration.html.
+* This version upgrades the SDK to use Log4j version 2.3.2 which contains a fix for [Security Vulnerability CVE-2021-44832](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-44832). The Log4j upgrade introduces breaking changes to the way Log4j is configured. This version of the SDK is using the Log4j2 bridge to help with version migration. If you override Log4j properties they might need to be converted to the new Log4j2 format. Please see this link for more details on migrating to Log4j v2: https://logging.apache.org/log4j/log4j-2.3.2/manual/migration.html.
 
 New Features in Version 1.5.1
 ------------

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ the Javadocs at http://salesforce-marketingcloud.github.io/FuelSDK-Java/.
 
 New Features in Version 1.6.0
 ------------
-* This version upgrades SDK to use log4j version 2.3.2 that contains fix for Security Vulnerability CVE-2021-44832. Log4j upgrade introduces breaking changes to the way log4j is configured. This version of SDK is using Log4j2 bridge to help mitigate the issue. If client overrides log4j properties they might need to be converted to the new log4j2 format. Please see this link for more details on migrating to log4j v2: https://logging.apache.org/log4j/log4j-2.3.2/manual/migration.html.
+* This version upgrades SDK to use log4j version 2.3.2 that contains fix for [Security Vulnerability CVE-2021-44832](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-44832). Log4j upgrade introduces breaking changes to the way log4j is configured. This version of SDK is using Log4j2 bridge to help with version migration. If client overrides log4j properties they might need to be converted to the new log4j2 format. Please see this link for more details on migrating to log4j v2: https://logging.apache.org/log4j/log4j-2.3.2/manual/migration.html.
 
 New Features in Version 1.5.1
 ------------

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.salesforce-marketingcloud</groupId>
   <artifactId>fuelsdk</artifactId>
-  <version>1.5.1</version>
+  <version>1.6.0</version>
   <name>Salesforce Marketing Cloud Java SDK</name>
   <description>Salesforce Marketing Cloud Java SDK</description>
   <url>https://github.com/salesforce-marketingcloud/FuelSDK-Java</url>
@@ -37,7 +37,7 @@
     <gson.version>2.3.1</gson.version>
     <junit.version>4.12</junit.version>
     <lang.version>2.6</lang.version>
-    <log4j.version>1.2.17</log4j.version>
+    <log4j.version>2.3.2</log4j.version>
     <javax.jaxb.version>2.3.0</javax.jaxb.version>
     <com.sun.jaxb.version>2.3.0</com.sun.jaxb.version>
     <com.sun.saaj.version>1.5.0</com.sun.saaj.version>
@@ -133,8 +133,8 @@
       <version>${lang.version}</version>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
       <version>${log4j.version}</version>
     </dependency>
     <dependency>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,15 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="info" strict="true" name="XMLConfigTest"
-               packages="org.apache.logging.log4j.test">
-  <!-- <Properties>
-    <Property name="filename">target/test.log</Property>
-  </Properties> -->
-
-  <!-- <Filter type="ThresholdFilter" level="trace"/> -->
- 
+<Configuration strict="true">
   <Appenders>
     <Appender type="Console" name="A1">
-        <Layout type="PatternLayout" pattern="xml----%d %-5p %c: %m%n" />
+        <Layout type="PatternLayout" pattern="%d %-5p %c: %m%n" />
         <Filters>
             <Filter type="ThresholdFilter" level="trace" />
         </Filters>
@@ -17,7 +10,7 @@
 
     <Appender type="File" name="FILE" fileName="c://Logging/fuelsdk.log">
         <Layout type="PatternLayout">
-            <Pattern>xml----%d %-5p %c: %m%n</Pattern>
+            <Pattern>%d %-5p %c: %m%n</Pattern>
         </Layout>
         <Filters>
             <Filter type="ThresholdFilter" level="trace" />

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -50,7 +50,7 @@
 <!-- Apache CXF's INFO level logging is a bit chatty: -->
     <Logger name="org.apache.cxf" level="warn" additivity="false">
       <AppenderRef ref="A1"/>
-      <AppenderRef ref="FILE"/>
+        <!-- <AppenderRef ref="FILE"/> -->
     </Logger> -->
     <!-- <Logger name="org.apache.cxf" level="info" additivity="false" /> -->
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="info" strict="true" name="XMLConfigTest"
+               packages="org.apache.logging.log4j.test">
+  <!-- <Properties>
+    <Property name="filename">target/test.log</Property>
+  </Properties> -->
+
+  <!-- <Filter type="ThresholdFilter" level="trace"/> -->
+ 
+  <Appenders>
+    <Appender type="Console" name="A1">
+        <Layout type="PatternLayout" pattern="xml----%d %-5p %c: %m%n" />
+        <Filters>
+            <Filter type="ThresholdFilter" level="trace" />
+        </Filters>
+    </Appender>
+
+    <Appender type="File" name="FILE" fileName="c://Logging/fuelsdk.log">
+        <Layout type="PatternLayout">
+            <Pattern>xml----%d %-5p %c: %m%n</Pattern>
+        </Layout>
+        <Filters>
+            <Filter type="ThresholdFilter" level="trace" />
+        </Filters>
+    </Appender>
+
+  </Appenders>
+ 
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="A1"/>
+      <!-- <AppenderRef ref="FILE"/> -->
+    </Root>
+
+  <!-- Fuel Java SDK: -->
+    <!-- <Logger name="com.exacttarget.fuelsdk" level="trace" additivity="false">
+      <AppenderRef ref="A1"/>
+      <AppenderRef ref="FILE"/>
+    </Logger> -->
+
+    <!-- <Logger name="com.exacttarget.fuelsdk.ETApiObject" level="TRACE" additivity="false"/> -->
+    <!-- <Logger name="com.exacttarget.fuelsdk.ETExpressionParser" level="TRACE" additivity="false"/> -->
+    <!-- <Logger name="com.exacttarget.fuelsdk.ETClient" level="debug" additivity="false">
+      <AppenderRef ref="A1"/>
+      <AppenderRef ref="FILE"/>
+    </Logger> -->
+    <!-- <Logger name="com.exacttarget.fuelsdk.ETConfiguration" level="DEBUG" additivity="false"/> -->
+    <!-- <Logger name="com.exacttarget.fuelsdk.ETDataExtension" level="DEBUG" additivity="false"/> -->
+    <!-- <Logger name="com.exacttarget.fuelsdk.ETExpression" level="DEBUG" additivity="false"/> -->
+    <!-- <Logger name="com.exacttarget.fuelsdk.ETRestConnection" level="DEBUG" additivity="false"/> -->
+    <!-- <Logger name="com.exacttarget.fuelsdk.ETRestObject" level="DEBUG" additivity="false"/> -->
+    <!-- <Logger name="com.exacttarget.fuelsdk.ETSoapConnection" level="DEBUG" additivity="false"/> -->
+    <!-- <Logger name="com.exacttarget.fuelsdk.ETSoapObject" level="DEBUG" additivity="false"/> -->
+    <!-- <Logger name="com.exacttarget.fuelsdk.ETTriggeredEmail" level="DEBUG" additivity="false"/> -->
+
+<!-- Apache CXF: -->
+<!-- Apache CXF's INFO level logging is a bit chatty: -->
+    <Logger name="org.apache.cxf" level="warn" additivity="false">
+      <AppenderRef ref="A1"/>
+      <AppenderRef ref="FILE"/>
+    </Logger> -->
+    <!-- <Logger name="org.apache.cxf" level="info" additivity="false" /> -->
+
+<!-- Apache BeanUtils: -->
+    <!-- <Logger name="org.apache.commons.beanutils" level="info" additivity="false" /> -->
+
+  </Loggers>
+ 
+</Configuration>


### PR DESCRIPTION
This PR upgrades log4j to v 2.3.2 in order to fix issue #133. This upgrade introduces breaking changes related to log4j configuration. See readme for more details.